### PR TITLE
Accelerate the judgement of sequence and unsequence data

### DIFF
--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/DataRegion.java
@@ -859,7 +859,9 @@ public class DataRegion implements IDataRegionForQuery {
       boolean isSequence =
           insertRowNode.getTime()
               > lastFlushTimeMap.getFlushedTime(
-                  timePartitionId, insertRowNode.getDevicePath().getFullPath());
+                  timePartitionId,
+                  insertRowNode.getDevicePath().getFullPath(),
+                  insertRowNode.getTime());
 
       // is unsequence and user set config to discard out of order data
       if (!isSequence
@@ -944,7 +946,9 @@ public class DataRegion implements IDataRegionForQuery {
 
       long lastFlushTime =
           lastFlushTimeMap.getFlushedTime(
-              beforeTimePartition, insertTabletNode.getDevicePath().getFullPath());
+              beforeTimePartition,
+              insertTabletNode.getDevicePath().getFullPath(),
+              insertTabletNode.getTimes()[loc]);
 
       // if is sequence
       boolean isSequence = false;
@@ -2714,7 +2718,9 @@ public class DataRegion implements IDataRegionForQuery {
           isSequence =
               insertRowNode.getTime()
                   > lastFlushTimeMap.getFlushedTime(
-                      timePartitionId, insertRowNode.getDevicePath().getFullPath());
+                      timePartitionId,
+                      insertRowNode.getDevicePath().getFullPath(),
+                      insertRowNode.getTime());
         }
         // is unsequence and user set config to discard out of order data
         if (!isSequence

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/ILastFlushTimeMap.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/ILastFlushTimeMap.java
@@ -56,7 +56,7 @@ public interface ILastFlushTimeMap {
   // endregion
 
   // region read
-  long getFlushedTime(long timePartitionId, String path);
+  long getFlushedTime(long timePartitionId, String path, long time);
 
   long getGlobalFlushedTime(String path);
   // endregion

--- a/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
+++ b/iotdb-core/datanode/src/main/java/org/apache/iotdb/db/storageengine/dataregion/tsfile/TsFileResource.java
@@ -462,6 +462,7 @@ public class TsFileResource {
       }
       return (DeviceTimeIndex) timeIndexFromResourceFile;
     } catch (Exception e) {
+      LOGGER.error("Can't read file {} from disk ", file.getPath() + RESOURCE_SUFFIX, e);
       throw new IOException(
           "Can't read file " + file.getPath() + RESOURCE_SUFFIX + " from disk", e);
     } finally {

--- a/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
+++ b/iotdb-core/datanode/src/test/java/org/apache/iotdb/db/storageengine/dataregion/LastFlushTimeMapTest.java
@@ -90,12 +90,12 @@ public class LastFlushTimeMapTest {
       tsfileProcessor.syncFlush();
     }
     Assert.assertEquals(
-        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0", 0));
 
     dataRegion.getLastFlushTimeMap().clearFlushedTime();
     dataRegion.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0);
     Assert.assertEquals(
-        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0", 0));
   }
 
   @Test
@@ -122,7 +122,7 @@ public class LastFlushTimeMapTest {
     }
     dataRegion.syncCloseAllWorkingTsFileProcessors();
     Assert.assertEquals(
-        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0", 0));
 
     dataRegion.getLastFlushTimeMap().clearFlushedTime();
     dataRegion.getLastFlushTimeMap().checkAndCreateFlushedTimePartition(0);
@@ -135,6 +135,6 @@ public class LastFlushTimeMapTest {
       res.degradeTimeIndex();
     }
     Assert.assertEquals(
-        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0"));
+        10000, dataRegion.getLastFlushTimeMap().getFlushedTime(0, "root.vehicle.d0", 0));
   }
 }


### PR DESCRIPTION
First obtain fileEndTime from memory. If it is out of order, deserialize resource file to get deviceEndTime from disk. Only put device end time into lastFlushTime map.